### PR TITLE
Rework CodeViewEditor to generate/manage PHP project tree and sync design panel

### DIFF
--- a/src/components/CodeViewEditor.tsx
+++ b/src/components/CodeViewEditor.tsx
@@ -1,10 +1,21 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect, useRef } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { ComponentData } from "../App"
 import { Button } from "./ui/button"
-import { Copy, Download, ChevronRight, ChevronDown, File, FilePlus, FolderPlus, Trash2, Save, Edit } from "lucide-react"
+import {
+  Copy,
+  Download,
+  ChevronRight,
+  ChevronDown,
+  File,
+  FilePlus,
+  FolderPlus,
+  Trash2,
+  Save,
+  Edit,
+} from "lucide-react"
 import { toast } from "sonner"
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism"
@@ -23,369 +34,161 @@ interface FileNode {
   name: string
   type: "file" | "folder"
   path: string
-  content?: string
   children?: FileNode[]
-  icon?: React.ReactNode
 }
 
-/* --- Simple file type icons --- */
-const HTMLIcon = () => (
-  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="2" y="2" width="20" height="20" rx="2" fill="#e34c26" />
-  </svg>
-)
-const CSSIcon = () => (
-  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="2" y="2" width="20" height="20" rx="2" fill="#264de4" />
-  </svg>
-)
-const JSIcon = () => (
-  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="2" y="2" width="20" height="20" rx="2" fill="#f7df1e" />
-  </svg>
-)
-const JSONIcon = () => (
-  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="2" y="2" width="20" height="20" rx="2" fill="#d13d07" />
-  </svg>
-)
-const MarkdownIcon = () => (
-  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="2" y="2" width="20" height="20" rx="2" fill="#2c2c2c" />
-  </svg>
-)
+const AUTO_GENERATED_FILES = new Set([
+  "public/index.php",
+  "app/views/layout.php",
+  "app/views/generated-components.php",
+  "public/assets/css/styles.css",
+  "public/assets/js/app.js",
+  "config/database.php",
+  "database/schema.sql",
+  "README.md",
+])
 
-// Helper function to convert camelCase to kebab-case
-const camelToKebab = (str: string): string => {
-  return str.replace(/([A-Z])/g, '-$1').toLowerCase()
-}
+const PHPIcon = () => <span className="text-[10px] font-bold text-[#8892bf]">PHP</span>
+const CSSIcon = () => <span className="text-[10px] font-bold text-[#3fa9f5]">CSS</span>
+const JSIcon = () => <span className="text-[10px] font-bold text-[#f7df1e]">JS</span>
+const SQLIcon = () => <span className="text-[10px] font-bold text-[#f29111]">SQL</span>
+const MarkdownIcon = () => <span className="text-[10px] font-bold text-[#9ca3af]">MD</span>
 
-// Helper function to extract and format CSS properties
-const extractStyles = (style: Record<string, any> = {}): string => {
-  const cssProperties: Record<string, string> = {}
+const camelToKebab = (value: string): string => value.replace(/([A-Z])/g, "-$1").toLowerCase()
 
-  Object.entries(style).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') {
-      const kebabKey = camelToKebab(key)
+const isUnitless = (key: string) => ["opacity", "zIndex", "fontWeight", "lineHeight", "flex", "order"].includes(key)
 
-      // Handle numeric values that need px
-      if (typeof value === 'number' && !['opacity', 'zIndex', 'fontWeight', 'lineHeight', 'flex', 'order'].includes(key)) {
-        cssProperties[kebabKey] = `${value}px`
-      } else {
-        cssProperties[kebabKey] = String(value)
-      }
+const toCssInline = (style: Record<string, any> = {}): string =>
+  Object.entries(style)
+    .filter(([, value]) => value !== undefined && value !== null && value !== "")
+    .map(([key, value]) => `${camelToKebab(key)}: ${typeof value === "number" && !isUnitless(key) ? `${value}px` : value}`)
+    .join("; ")
+
+const slugify = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "") || "field"
+
+const walkComponents = (components: ComponentData[], callback: (component: ComponentData) => void) => {
+  components.forEach((component) => {
+    callback(component)
+    if (component.children?.length) {
+      walkComponents(component.children, callback)
     }
   })
-
-  return Object.entries(cssProperties)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join('; ')
 }
 
-// Generate exact HTML from canvas components - IMPROVED VERSION
-const generateHTMLFromComponents = (components: ComponentData[]): string => {
-  const renderComponent = (comp: ComponentData, isNested = false, depth = 0): string => {
-    const position = comp.position || { x: 0, y: 0 }
-    const style = comp.style || {}
-    const props = comp.props || {}
-
-    // Build complete style object with positioning
-    const completeStyle: Record<string, any> = {
-      ...(isNested ? {} : {
-        position: 'absolute',
-        left: `${position.x}px`,
-        top: `${position.y}px`
-      }),
-      ...style
-    }
-
-    const styleStr = extractStyles(completeStyle)
-    const indent = '  '.repeat(depth + 2)
-
-    let content = ''
-    let tag = 'div'
-    let attributes: string[] = []
-
-    switch (comp.type) {
-      case 'text':
-        tag = 'p'
-        content = props.content || props.text || 'Text'
-        break
-
-      case 'heading':
-        tag = `h${props.level || 1}`
-        content = props.content || props.text || 'Heading'
-        break
-
-      case 'button':
-        tag = 'button'
-        content = props.content || props.text || props.label || 'Button'
-        if (props.onClick) {
-          attributes.push(`onclick="${props.onClick}"`)
-        }
-        break
-
-      case 'image':
-        tag = 'img'
-        const imgSrc = props.src || props.url || 'https://via.placeholder.com/300x200'
-        const imgAlt = props.alt || 'Image'
-        attributes.push(`src="${imgSrc}"`)
-        attributes.push(`alt="${imgAlt}"`)
-        break
-
-      case 'input':
-        tag = 'input'
-        const inputType = props.type || 'text'
-        const placeholder = props.placeholder || ''
-        attributes.push(`type="${inputType}"`)
-        if (placeholder) {
-          attributes.push(`placeholder="${placeholder}"`)
-        }
-        if (props.value) {
-          attributes.push(`value="${props.value}"`)
-        }
-        if (props.name) {
-          attributes.push(`name="${props.name}"`)
-        }
-        break
-
-      case 'textarea':
-        tag = 'textarea'
-        content = props.value || props.content || ''
-        if (props.placeholder) {
-          attributes.push(`placeholder="${props.placeholder}"`)
-        }
-        if (props.rows) {
-          attributes.push(`rows="${props.rows}"`)
-        }
-        if (props.cols) {
-          attributes.push(`cols="${props.cols}"`)
-        }
-        break
-
-      case 'link':
-        tag = 'a'
-        content = props.content || props.text || 'Link'
-        if (props.href) {
-          attributes.push(`href="${props.href}"`)
-        }
-        if (props.target) {
-          attributes.push(`target="${props.target}"`)
-        }
-        break
-
-      case 'container':
-      case 'group':
-      case 'div':
-        tag = 'div'
-        if (props.className) {
-          attributes.push(`class="${props.className}"`)
-        }
-        // Handle children properly
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        } else {
-          content = props.content || props.text || ''
-        }
-        break
-
-      case 'section':
-        tag = 'section'
-        if (props.className) {
-          attributes.push(`class="${props.className}"`)
-        }
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        }
-        break
-
-      case 'form':
-        tag = 'form'
-        if (props.action) {
-          attributes.push(`action="${props.action}"`)
-        }
-        if (props.method) {
-          attributes.push(`method="${props.method}"`)
-        }
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        }
-        break
-
-      case 'list':
-        tag = props.ordered ? 'ol' : 'ul'
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        }
-        break
-
-      case 'listItem':
-        tag = 'li'
-        content = props.content || props.text || 'List Item'
-        break
-
-      case 'video':
-        tag = 'video'
-        if (props.src) {
-          attributes.push(`src="${props.src}"`)
-        }
-        if (props.controls !== false) {
-          attributes.push('controls')
-        }
-        if (props.autoplay) {
-          attributes.push('autoplay')
-        }
-        if (props.loop) {
-          attributes.push('loop')
-        }
-        break
-
-      case 'audio':
-        tag = 'audio'
-        if (props.src) {
-          attributes.push(`src="${props.src}"`)
-        }
-        if (props.controls !== false) {
-          attributes.push('controls')
-        }
-        break
-
-      case 'navbar':
-      case 'header':
-        tag = 'header'
-        attributes.push(`class="navbar"`)
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        } else {
-          // Default navbar structure if no children
-          content = props.content || props.text || ''
-        }
-        break
-
-      case 'footer':
-        tag = 'footer'
-        attributes.push(`class="footer"`)
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        } else {
-          // Default footer structure if no children
-          content = props.content || props.text || ''
-        }
-        break
-
-      default:
-        tag = 'div'
-        if (comp.children && comp.children.length > 0) {
-          const childIndent = '  '.repeat(depth + 3)
-          content = '\n' + comp.children.map(child =>
-            childIndent + renderComponent(child, true, depth + 1)
-          ).join('\n') + '\n' + indent
-        } else {
-          content = props.content || props.text || comp.type
-        }
-    }
-
-    // Build the attributes string
-    const attrsStr = attributes.length > 0 ? ' ' + attributes.join(' ') : ''
-
-    // Self-closing tags
-    if (['img', 'input', 'br', 'hr'].includes(tag)) {
-      return `<${tag}${attrsStr} style="${styleStr}" />`
-    }
-
-    return `<${tag}${attrsStr} style="${styleStr}">${content}</${tag}>`
+const renderComponentToPHP = (component: ComponentData, depth = 0, nested = false): string => {
+  const indent = "  ".repeat(depth)
+  const position = component.position ?? { x: 0, y: 0 }
+  const styles = {
+    ...(nested
+      ? {}
+      : {
+          position: "absolute",
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+        }),
+    ...(component.style ?? {}),
   }
+  const styleAttr = toCssInline(styles)
+  const attrs: string[] = styleAttr ? [`style="${styleAttr}"`] : []
+  const props = component.props ?? {}
 
-  const componentsHTML = components.map(comp => '    ' + renderComponent(comp, false, 0)).join('\n')
+  const childOutput = (component.children ?? [])
+    .map((child) => renderComponentToPHP(child, depth + 1, true))
+    .join("\n")
 
-  return `<!DOCTYPE html>
+  switch (component.type) {
+    case "heading": {
+      const level = Math.min(6, Math.max(1, Number(props.level || 1)))
+      return `${indent}<h${level} ${attrs.join(" ")}>${props.content || props.text || "Heading"}</h${level}>`
+    }
+    case "text":
+      return `${indent}<p ${attrs.join(" ")}>${props.content || props.text || "Text"}</p>`
+    case "button":
+      return `${indent}<button type=\"button\" ${attrs.join(" ")}>${props.content || props.text || props.label || "Button"}</button>`
+    case "image":
+      return `${indent}<img src=\"${props.src || "https://via.placeholder.com/320x180"}\" alt=\"${props.alt || "Image"}\" ${attrs.join(" ")} />`
+    case "input":
+      return `${indent}<input type=\"${props.type || "text"}\" name=\"${props.name || slugify(props.placeholder || "input")}_${component.id.slice(0, 6)}\" placeholder=\"${props.placeholder || ""}\" ${attrs.join(" ")} />`
+    case "textarea":
+      return `${indent}<textarea name=\"${props.name || `message_${component.id.slice(0, 6)}`}\" ${attrs.join(" ")}>${props.value || props.content || ""}</textarea>`
+    case "link":
+      return `${indent}<a href=\"${props.href || "#"}\" ${attrs.join(" ")}>${props.content || props.text || "Link"}</a>`
+    case "form":
+      return `${indent}<form method=\"${props.method || "POST"}\" action=\"${props.action || ""}\" ${attrs.join(" ")}>
+${childOutput}
+${indent}</form>`
+    case "list": {
+      const tag = props.ordered ? "ol" : "ul"
+      return `${indent}<${tag} ${attrs.join(" ")}>
+${childOutput}
+${indent}</${tag}>`
+    }
+    case "listItem":
+      return `${indent}<li ${attrs.join(" ")}>${props.content || props.text || "List Item"}</li>`
+    case "section":
+    case "container":
+    case "group":
+    case "div":
+    default:
+      return `${indent}<div ${attrs.join(" ")}>
+${childOutput || `${indent}  ${props.content || props.text || component.type}`}
+${indent}</div>`
+  }
+}
+
+const generateComponentPHP = (components: ComponentData[]): string => {
+  const body = components.length
+    ? components.map((component) => renderComponentToPHP(component, 1)).join("\n")
+    : "  <div>No components in the design panel yet.</div>"
+
+  return `<?php\n// Auto-generated from the design panel.\n?>\n<div class=\"canvas-container\">\n${body}\n</div>\n`
+}
+
+const generateLayoutPHP = (projectName: string): string => `<?php
+// Shared layout file for ${projectName}
+?><!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Generated Project</title>
-  <link rel="stylesheet" href="css/styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${projectName}</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
 <body>
-  <div class="canvas-container">
-${componentsHTML}
-  </div>
-  <script src="js/main.js"></script>
+  <?php include __DIR__ . '/generated-components.php'; ?>
+  <script src="assets/js/app.js"></script>
 </body>
-</html>`
-}
+</html>
+`
 
-// Generate CSS from components - IMPROVED VERSION
-const generateCSSFromComponents = (components: ComponentData[]): string => {
-  // Collect all unique class names and their styles
+const generateIndexPHP = (): string => `<?php
+require_once __DIR__ . '/../config/database.php';
+include __DIR__ . '/../app/views/layout.php';
+`
+
+const generateCSS = (components: ComponentData[]): string => {
   const classStyles: Record<string, string[]> = {}
 
-  const extractComponentStyles = (comp: ComponentData): void => {
-    // Extract class-based styles
-    if (comp.props?.className) {
-      const className = comp.props.className
-      if (!classStyles[className]) {
-        classStyles[className] = []
+  walkComponents(components, (component) => {
+    const className = component.props?.className
+    if (!className || !component.style) return
+
+    if (!classStyles[className]) {
+      classStyles[className] = []
+    }
+
+    Object.entries(component.style).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === "") return
+      const cssRule = `${camelToKebab(key)}: ${typeof value === "number" && !isUnitless(key) ? `${value}px` : value};`
+      if (!classStyles[className].includes(cssRule)) {
+        classStyles[className].push(cssRule)
       }
-
-      // Add component-specific styles
-      if (comp.style) {
-        Object.entries(comp.style).forEach(([key, value]) => {
-          if (value !== undefined && value !== null && value !== '') {
-            const kebabKey = camelToKebab(key)
-            let cssValue = value
-
-            if (typeof value === 'number' && !['opacity', 'zIndex', 'fontWeight', 'lineHeight', 'flex', 'order'].includes(key)) {
-              cssValue = `${value}px`
-            }
-
-            const styleRule = `${kebabKey}: ${cssValue};`
-            if (!classStyles[className].includes(styleRule)) {
-              classStyles[className].push(styleRule)
-            }
-          }
-        })
-      }
-    }
-
-    // Recursively process children
-    if (comp.children) {
-      comp.children.forEach(child => extractComponentStyles(child))
-    }
-  }
-
-  // Extract styles from all components
-  components.forEach(comp => extractComponentStyles(comp))
-
-  // Generate class-based CSS
-  let additionalStyles = ''
-  Object.entries(classStyles).forEach(([className, styles]) => {
-    if (styles.length > 0) {
-      additionalStyles += `.${className} {\n`
-      styles.forEach(style => {
-        additionalStyles += `  ${style}\n`
-      })
-      additionalStyles += `}\n\n`
-    }
+    })
   })
+
+  const generatedClasses = Object.entries(classStyles)
+    .map(([name, rules]) => `.${name} {\n${rules.map((rule) => `  ${rule}`).join("\n")}\n}`)
+    .join("\n\n")
 
   return `* {
   margin: 0;
@@ -394,166 +197,140 @@ const generateCSSFromComponents = (components: ComponentData[]): string => {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background-color: #f5f5f5;
-  overflow-x: hidden;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f3f4f6;
 }
 
 .canvas-container {
-  position: relative;
   min-height: 100vh;
-  background-color: white;
+  position: relative;
+  background: #ffffff;
 }
 
-/* Navbar Styles */
-.navbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 2rem;
-  background-color: #ffffff;
-  border-bottom: 1px solid #e5e5e5;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-
-.navbar nav {
-  display: flex;
-  gap: 2rem;
-}
-
-.navbar a {
-  text-decoration: none;
-  color: #333;
-  font-weight: 500;
-  transition: color 0.2s;
-}
-
-.navbar a:hover {
-  color: #0066cc;
-}
-
-/* Footer Styles */
-.footer {
-  padding: 2rem;
-  background-color: #f8f9fa;
-  border-top: 1px solid #e5e5e5;
-  text-align: center;
-}
-
-button {
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background-color: #0066cc;
-  color: white;
-  font-size: 1rem;
-}
-
-button:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
-}
-
-img {
-  display: block;
-  object-fit: cover;
-  max-width: 100%;
-  height: auto;
-}
-
-input, textarea {
-  font-family: inherit;
-  font-size: inherit;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-
-input:focus, textarea:focus {
-  outline: none;
-  border-color: #0066cc;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  font-weight: 600;
-  line-height: 1.2;
-  margin-bottom: 0.5rem;
-}
-
-p {
-  line-height: 1.6;
-  margin-bottom: 1rem;
-}
-
-a {
-  text-decoration: none;
-  color: #0066cc;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-ul, ol {
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-section {
-  padding: 2rem;
-}
-
-${additionalStyles}
-/* Add your custom styles below */
+${generatedClasses}
 `
 }
 
-// Generate JavaScript
-const generateJavaScript = (): string => {
-  return `// Main JavaScript file
-console.log('Project loaded successfully!');
+const generateJS = (): string => `document.addEventListener("DOMContentLoaded", () => {
+  console.log("PHP project generated from design panel loaded.");
 
-// Add your interactive code here
-document.addEventListener('DOMContentLoaded', () => {
-  console.log('DOM ready');
-  
-  // Example: Add click handlers to buttons
-  const buttons = document.querySelectorAll('button');
-  buttons.forEach(button => {
-    button.addEventListener('click', (e) => {
-      console.log('Button clicked:', e.target.textContent);
+  document.querySelectorAll("form").forEach((form) => {
+    form.addEventListener("submit", (event) => {
+      if (form.getAttribute("data-preview") === "true") {
+        event.preventDefault();
+      }
     });
   });
-  
-  // Example: Form handling
-  const forms = document.querySelectorAll('form');
-  forms.forEach(form => {
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      console.log('Form submitted');
-      // Add your form handling logic here
-    });
-  });
-
-  // Example: Navbar mobile menu toggle
-  const navbarToggle = document.querySelector('.navbar-toggle');
-  const navbarMenu = document.querySelector('.navbar-menu');
-  
-  if (navbarToggle && navbarMenu) {
-    navbarToggle.addEventListener('click', () => {
-      navbarMenu.classList.toggle('active');
-    });
-  }
 });
 `
+
+const generateSchemaSQL = (components: ComponentData[]): string => {
+  const formTables: string[] = []
+  const usedTableNames = new Set<string>()
+
+  walkComponents(components, (component) => {
+    if (component.type !== "form") return
+
+    const baseName = slugify(component.props?.name || component.props?.id || "form_submission")
+    let tableName = `form_${baseName}`
+    let counter = 1
+    while (usedTableNames.has(tableName)) {
+      tableName = `form_${baseName}_${counter++}`
+    }
+    usedTableNames.add(tableName)
+
+    const fields = new Set<string>(["id INT AUTO_INCREMENT PRIMARY KEY", "submitted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"])
+
+    walkComponents(component.children || [], (child) => {
+      if (!["input", "textarea", "select"].includes(child.type)) return
+      const fieldName = slugify(child.props?.name || child.props?.placeholder || `${child.type}_${child.id.slice(0, 6)}`)
+      fields.add(`${fieldName} TEXT NULL`)
+    })
+
+    formTables.push(`CREATE TABLE IF NOT EXISTS ${tableName} (\n  ${Array.from(fields).join(",\n  ")}\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`)
+  })
+
+  return `-- Auto-generated schema based on design panel components
+CREATE TABLE IF NOT EXISTS generated_pages (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  project_name VARCHAR(255) NOT NULL,
+  page_slug VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+${formTables.join("\n\n") || "-- No form components detected; add forms to generate submission tables."}
+`
 }
 
-export function CodeViewEditor({ components, projectName = "web-project" }: CodeViewEditorProps) {
-  const [selectedFile, setSelectedFile] = useState<string>("index.html")
-  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set(["root", "css", "js"]))
-  const [fileStructure, setFileStructure] = useState<FileNode[]>([])
+const generateDatabaseConfigPHP = (): string => `<?php
+$DB_HOST = getenv('DB_HOST') ?: '127.0.0.1';
+$DB_NAME = getenv('DB_NAME') ?: 'builder_output';
+$DB_USER = getenv('DB_USER') ?: 'root';
+$DB_PASS = getenv('DB_PASS') ?: '';
+
+try {
+    $pdo = new PDO("mysql:host={$DB_HOST};dbname={$DB_NAME};charset=utf8mb4", $DB_USER, $DB_PASS, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $exception) {
+    die("Database connection failed: " . $exception->getMessage());
+}
+`
+
+const buildGeneratedFiles = (components: ComponentData[], projectName: string): Record<string, string> => ({
+  "public/index.php": generateIndexPHP(),
+  "app/views/layout.php": generateLayoutPHP(projectName),
+  "app/views/generated-components.php": generateComponentPHP(components),
+  "public/assets/css/styles.css": generateCSS(components),
+  "public/assets/js/app.js": generateJS(),
+  "config/database.php": generateDatabaseConfigPHP(),
+  "database/schema.sql": generateSchemaSQL(components),
+  "README.md": `# ${projectName}\n\nGenerated PHP project synchronized with your drag-and-drop design panel.\n\n## Folder structure\n- public/index.php\n- app/views/layout.php\n- app/views/generated-components.php\n- public/assets/css/styles.css\n- public/assets/js/app.js\n- config/database.php\n- database/schema.sql\n`,
+})
+
+const buildTreeFromPaths = (paths: string[]): FileNode[] => {
+  const root: FileNode = { name: "root", type: "folder", path: "", children: [] }
+
+  paths.forEach((path) => {
+    const segments = path.split("/")
+    let current = root
+
+    segments.forEach((segment, index) => {
+      const currentPath = segments.slice(0, index + 1).join("/")
+      const isFile = index === segments.length - 1 && segment.includes(".")
+
+      if (!current.children) current.children = []
+      let node = current.children.find((item) => item.path === currentPath)
+
+      if (!node) {
+        node = {
+          name: segment,
+          type: isFile ? "file" : "folder",
+          path: currentPath,
+          children: isFile ? undefined : [],
+        }
+        current.children.push(node)
+      }
+
+      current = node
+    })
+  })
+
+  const sortNodes = (nodes: FileNode[]): FileNode[] =>
+    [...nodes]
+      .sort((a, b) => {
+        if (a.type === b.type) return a.name.localeCompare(b.name)
+        return a.type === "folder" ? -1 : 1
+      })
+      .map((node) => ({ ...node, children: node.children ? sortNodes(node.children) : undefined }))
+
+  return sortNodes(root.children ?? [])
+}
+
+export function CodeViewEditor({ components, projectName = "php-builder-project" }: CodeViewEditorProps) {
+  const [selectedFile, setSelectedFile] = useState<string>("public/index.php")
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set(["public", "app", "app/views", "public/assets"]))
   const [fileContents, setFileContents] = useState<Record<string, string>>({})
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState("")
@@ -561,442 +338,279 @@ export function CodeViewEditor({ components, projectName = "web-project" }: Code
   const [showNewFolderDialog, setShowNewFolderDialog] = useState(false)
   const [newFileName, setNewFileName] = useState("")
   const [newFolderName, setNewFolderName] = useState("")
-  const [isDownloading, setIsDownloading] = useState(false)
 
-  // Initialize file structure and contents whenever components change
   useEffect(() => {
-    const htmlContent = generateHTMLFromComponents(components)
-    const cssContent = generateCSSFromComponents(components)
-    const jsContent = generateJavaScript()
+    const generated = buildGeneratedFiles(components, projectName)
 
-    const structure: FileNode[] = [
-      {
-        name: "index.html",
-        type: "file",
-        path: "index.html",
-        content: htmlContent,
-        icon: <HTMLIcon />
-      },
-      {
-        name: "css",
-        type: "folder",
-        path: "css",
-        children: [
-          {
-            name: "styles.css",
-            type: "file",
-            path: "css/styles.css",
-            content: cssContent,
-            icon: <CSSIcon />
-          }
-        ]
-      },
-      {
-        name: "js",
-        type: "folder",
-        path: "js",
-        children: [
-          {
-            name: "main.js",
-            type: "file",
-            path: "js/main.js",
-            content: jsContent,
-            icon: <JSIcon />
-          }
-        ]
-      },
-      {
-        name: "README.md",
-        type: "file",
-        path: "README.md",
-        content: `# ${projectName}\n\nGenerated from canvas design.\n\n## Getting Started\n\nOpen index.html in your browser to view the project.\n\n## Project Structure\n\n- index.html - Main HTML file\n- css/styles.css - Stylesheet\n- js/main.js - JavaScript functionality\n\n## Components\n\nThis project contains ${components.length} component(s).\n\n## Features\n\n- Responsive design\n- Clean, semantic HTML\n- Modern CSS styling\n- Interactive JavaScript\n`,
-        icon: <MarkdownIcon />
-      }
-    ]
+    setFileContents((previous) => {
+      const next = { ...previous }
+      Object.entries(generated).forEach(([path, content]) => {
+        next[path] = content
+      })
+      return next
+    })
 
-    setFileStructure(structure)
-
-    const contents: Record<string, string> = {
-      "index.html": htmlContent,
-      "css/styles.css": cssContent,
-      "js/main.js": jsContent,
-      "README.md": `# ${projectName}\n\nGenerated from canvas design.\n\n## Getting Started\n\nOpen index.html in your browser to view the project.\n\n## Project Structure\n\n- index.html - Main HTML file\n- css/styles.css - Stylesheet\n- js/main.js - JavaScript functionality\n\n## Components\n\nThis project contains ${components.length} component(s).\n\n## Features\n\n- Responsive design\n- Clean, semantic HTML\n- Modern CSS styling\n- Interactive JavaScript\n`
+    if (!selectedFile) {
+      setSelectedFile("public/index.php")
     }
+  }, [components, projectName, selectedFile])
 
-    setFileContents(contents)
-  }, [components, projectName])
-
-  const getFileIcon = (fileName: string) => {
-    const ext = fileName.split(".").pop()?.toLowerCase()
-    if (ext === "html") return <HTMLIcon />
-    if (ext === "css") return <CSSIcon />
-    if (ext === "js") return <JSIcon />
-    if (ext === "json") return <JSONIcon />
-    if (ext === "md") return <MarkdownIcon />
-    return <File className="w-4 h-4 text-muted-foreground" />
-  }
+  const fileStructure = useMemo(() => buildTreeFromPaths(Object.keys(fileContents)), [fileContents])
 
   const toggleFolder = (path: string) => {
-    setExpandedFolders((prev) => {
-      const next = new Set(prev)
+    setExpandedFolders((previous) => {
+      const next = new Set(previous)
       if (next.has(path)) next.delete(path)
       else next.add(path)
       return next
     })
   }
 
+  const getBaseDirectory = () => {
+    if (!selectedFile) return ""
+    const selected = fileStructure.flatMap((node) => node.path)
+    if (selected.includes(selectedFile) && selectedFile.includes(".")) {
+      const parts = selectedFile.split("/")
+      parts.pop()
+      return parts.join("/")
+    }
+    return selectedFile
+  }
+
   const addNewFile = () => {
-    if (!newFileName.trim()) {
-      toast.error("Please enter a filename")
-      return
-    }
+    if (!newFileName.trim()) return toast.error("Please provide a file name")
+    const baseDir = getBaseDirectory()
+    const path = [baseDir, newFileName.trim()].filter(Boolean).join("/")
+    if (fileContents[path]) return toast.error("File already exists")
 
-    const newPath = selectedFile.includes('/')
-      ? `${selectedFile.split('/')[0]}/${newFileName}`
-      : newFileName
-
-    if (fileContents[newPath]) {
-      toast.error("File already exists")
-      return
-    }
-
-    const newFile: FileNode = {
-      name: newFileName,
-      type: "file",
-      path: newPath,
-      content: "",
-      icon: getFileIcon(newFileName)
-    }
-
-    setFileContents(prev => ({ ...prev, [newPath]: "" }))
-
-    // Add to structure
-    setFileStructure(prev => {
-      const updated = [...prev]
-      if (selectedFile.includes('/')) {
-        const folder = selectedFile.split('/')[0]
-        const folderNode = updated.find(n => n.path === folder)
-        if (folderNode && folderNode.children) {
-          folderNode.children.push(newFile)
-        }
-      } else {
-        updated.push(newFile)
-      }
-      return updated
-    })
-
-    setNewFileName("")
+    setFileContents((previous) => ({ ...previous, [path]: "" }))
+    setSelectedFile(path)
     setShowNewFileDialog(false)
-    setSelectedFile(newPath)
-    toast.success("File created successfully")
+    setNewFileName("")
+    toast.success("File created")
   }
 
   const addNewFolder = () => {
-    if (!newFolderName.trim()) {
-      toast.error("Please enter a folder name")
-      return
-    }
+    if (!newFolderName.trim()) return toast.error("Please provide a folder name")
+    const baseDir = getBaseDirectory()
+    const path = [baseDir, newFolderName.trim()].filter(Boolean).join("/")
+    const placeholder = `${path}/.gitkeep`
+    if (fileContents[placeholder]) return toast.error("Folder already exists")
 
-    if (fileStructure.find(n => n.path === newFolderName)) {
-      toast.error("Folder already exists")
-      return
-    }
-
-    const newFolder: FileNode = {
-      name: newFolderName,
-      type: "folder",
-      path: newFolderName,
-      children: []
-    }
-
-    setFileStructure(prev => [...prev, newFolder])
-    setExpandedFolders(prev => new Set([...prev, newFolderName]))
-    setNewFolderName("")
+    setFileContents((previous) => ({ ...previous, [placeholder]: "" }))
+    setExpandedFolders((previous) => new Set(previous).add(path))
     setShowNewFolderDialog(false)
-    toast.success("Folder created successfully")
+    setNewFolderName("")
+    toast.success("Folder created")
   }
 
-  const deleteFile = (path: string) => {
-    setFileContents(prev => {
-      const updated = { ...prev }
-      delete updated[path]
-      return updated
+  const deletePath = (path: string) => {
+    const isAutoGenerated = AUTO_GENERATED_FILES.has(path)
+    if (isAutoGenerated) return toast.error("Auto-generated files cannot be deleted")
+
+    setFileContents((previous) => {
+      const next: Record<string, string> = {}
+      Object.entries(previous).forEach(([filePath, content]) => {
+        if (filePath === path || filePath.startsWith(`${path}/`)) return
+        next[filePath] = content
+      })
+      return next
     })
 
-    setFileStructure(prev => {
-      const deleteFromStructure = (nodes: FileNode[]): FileNode[] => {
-        return nodes.filter(node => {
-          if (node.path === path) return false
-          if (node.children) {
-            node.children = deleteFromStructure(node.children)
-          }
-          return true
-        })
-      }
-      return deleteFromStructure([...prev])
-    })
-
-    if (selectedFile === path) {
-      setSelectedFile("index.html")
+    if (selectedFile === path || selectedFile.startsWith(`${path}/`)) {
+      setSelectedFile("public/index.php")
     }
-    toast.success("File deleted")
-  }
 
-  const renderFileTree = (nodes: FileNode[], depth = 0): React.ReactNode =>
-    nodes.map((node) => (
-      <div key={node.path}>
-        {node.type === "folder" ? (
-          <>
-            <div
-              className="flex items-center gap-1 px-2 py-1 cursor-pointer hover:bg-muted/50 rounded transition-colors group"
-              style={{ paddingLeft: `${depth * 16 + 8}px` }}
-            >
-              <div className="flex-1 flex items-center gap-1" onClick={() => toggleFolder(node.path)}>
-                {expandedFolders.has(node.path) ? (
-                  <ChevronDown className="w-4 h-4 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                )}
-                <span className="text-sm text-foreground font-medium">{node.name}</span>
-              </div>
-            </div>
-            {expandedFolders.has(node.path) && node.children && renderFileTree(node.children, depth + 1)}
-          </>
-        ) : (
-          <div
-            className={`flex items-center gap-2 px-2 py-1 cursor-pointer hover:bg-muted/50 rounded transition-colors group ${selectedFile === node.path ? "bg-muted" : ""
-              }`}
-            style={{ paddingLeft: `${depth * 16 + 28}px` }}
-            onClick={() => {
-              setSelectedFile(node.path)
-              setIsEditing(false)
-            }}
-          >
-            <div className="flex-1 flex items-center gap-2">
-              {node.icon}
-              <span className="text-sm text-foreground">{node.name}</span>
-            </div>
-            {!["index.html", "css/styles.css", "js/main.js", "README.md"].includes(node.path) && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  if (confirm(`Delete ${node.name}?`)) {
-                    deleteFile(node.path)
-                  }
-                }}
-                className="opacity-0 group-hover:opacity-100 p-1 hover:bg-destructive/10 rounded"
-              >
-                <Trash2 className="w-3 h-3 text-destructive" />
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-    ))
-
-  const handleEdit = () => {
-    setEditContent(fileContents[selectedFile] || "")
-    setIsEditing(true)
+    toast.success("Deleted")
   }
 
   const handleSave = () => {
-    setFileContents(prev => ({ ...prev, [selectedFile]: editContent }))
+    setFileContents((previous) => ({ ...previous, [selectedFile]: editContent }))
     setIsEditing(false)
     toast.success("File saved")
   }
 
   const copyCode = async () => {
-    const code = fileContents[selectedFile] || ""
     try {
-      await navigator.clipboard.writeText(code)
-      toast.success("Code copied to clipboard!")
+      await navigator.clipboard.writeText(fileContents[selectedFile] || "")
+      toast.success("Copied")
     } catch {
-      toast.error("Failed to copy code")
+      toast.error("Clipboard unavailable")
     }
   }
 
-  const downloadAsZip = async () => {
-    setIsDownloading(true)
-    try {
-      // Simple download implementation - creates data URLs for each file
-      const zip = Object.entries(fileContents)
-        .map(([path, content]) => `File: ${path}\n${'='.repeat(50)}\n${content}\n\n`)
-        .join('\n')
+  const downloadProject = () => {
+    const exportText = Object.entries(fileContents)
+      .map(([path, content]) => `FILE: ${path}\n${"=".repeat(40)}\n${content}`)
+      .join("\n\n")
 
-      const blob = new Blob([zip], { type: 'text/plain' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `${projectName}-code.txt`
-      a.click()
-      URL.revokeObjectURL(url)
-
-      toast.success("Project files downloaded!")
-    } catch (error) {
-      console.error("Download error:", error)
-      toast.error("Error downloading project")
-    } finally {
-      setIsDownloading(false)
-    }
+    const blob = new Blob([exportText], { type: "text/plain" })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = `${projectName}-php-project.txt`
+    anchor.click()
+    URL.revokeObjectURL(url)
+    toast.success("Project downloaded")
   }
 
-  const getLang = (filename: string) => {
-    if (filename.endsWith(".html")) return "html"
-    if (filename.endsWith(".css")) return "css"
-    if (filename.endsWith(".js")) return "javascript"
-    if (filename.endsWith(".json")) return "json"
-    if (filename.endsWith(".md")) return "markdown"
+  const getFileIcon = (path: string) => {
+    if (path.endsWith(".php")) return <PHPIcon />
+    if (path.endsWith(".css")) return <CSSIcon />
+    if (path.endsWith(".js")) return <JSIcon />
+    if (path.endsWith(".sql")) return <SQLIcon />
+    if (path.endsWith(".md")) return <MarkdownIcon />
+    return <File className="w-3.5 h-3.5 text-muted-foreground" />
+  }
+
+  const renderTree = (nodes: FileNode[], depth = 0): React.ReactNode =>
+    nodes.map((node) => {
+      if (node.name === ".gitkeep") return null
+
+      if (node.type === "folder") {
+        return (
+          <div key={node.path}>
+            <div
+              className="flex items-center gap-1 px-2 py-1 hover:bg-muted/40 rounded cursor-pointer"
+              style={{ paddingLeft: `${depth * 14 + 6}px` }}
+              onClick={() => {
+                setSelectedFile(node.path)
+                toggleFolder(node.path)
+              }}
+            >
+              {expandedFolders.has(node.path) ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              <span className="text-sm">{node.name}</span>
+              <button className="ml-auto opacity-0 group-hover:opacity-100" onClick={(event) => { event.stopPropagation(); deletePath(node.path) }}>
+                <Trash2 className="w-3 h-3 text-red-500" />
+              </button>
+            </div>
+            {expandedFolders.has(node.path) && node.children ? renderTree(node.children, depth + 1) : null}
+          </div>
+        )
+      }
+
+      return (
+        <div
+          key={node.path}
+          className={`group flex items-center gap-2 px-2 py-1 rounded cursor-pointer hover:bg-muted/40 ${selectedFile === node.path ? "bg-muted" : ""}`}
+          style={{ paddingLeft: `${depth * 14 + 20}px` }}
+          onClick={() => {
+            setSelectedFile(node.path)
+            setIsEditing(false)
+          }}
+        >
+          {getFileIcon(node.path)}
+          <span className="text-sm truncate flex-1">{node.name}</span>
+          {!AUTO_GENERATED_FILES.has(node.path) && (
+            <button
+              className="opacity-0 group-hover:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation()
+                deletePath(node.path)
+              }}
+            >
+              <Trash2 className="w-3 h-3 text-red-500" />
+            </button>
+          )}
+        </div>
+      )
+    })
+
+  const getLanguage = (path: string) => {
+    if (path.endsWith(".php")) return "php"
+    if (path.endsWith(".css")) return "css"
+    if (path.endsWith(".js")) return "javascript"
+    if (path.endsWith(".sql")) return "sql"
+    if (path.endsWith(".md")) return "markdown"
     return "text"
   }
 
   return (
-    <div className="w-full h-full flex flex-col gap-4">
-      <div className="w-full h-full flex gap-4">
-        {/* File Explorer - Left sidebar */}
-        <div className="w-64 bg-card border border-border rounded-md p-2 overflow-auto flex flex-col">
-          <div className="px-3 py-2 border-b border-border mb-2 flex items-center justify-between">
-            <h3 className="text-xs font-semibold text-muted-foreground uppercase">Explorer</h3>
-            <div className="flex gap-1">
-              <button
-                onClick={() => setShowNewFileDialog(true)}
-                className="p-1 hover:bg-muted rounded transition-colors"
-                title="New File"
-              >
-                <FilePlus className="w-4 h-4" />
-              </button>
-              <button
-                onClick={() => setShowNewFolderDialog(true)}
-                className="p-1 hover:bg-muted rounded transition-colors"
-                title="New Folder"
-              >
-                <FolderPlus className="w-4 h-4" />
-              </button>
-            </div>
+    <div className="w-full h-full flex gap-4">
+      <div className="w-72 border border-border rounded-md p-2 flex flex-col">
+        <div className="px-2 py-2 border-b border-border mb-2 flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase text-muted-foreground">PHP Explorer</span>
+          <div className="flex gap-1">
+            <button onClick={() => setShowNewFileDialog(true)} className="p-1 hover:bg-muted rounded" title="New File">
+              <FilePlus className="w-4 h-4" />
+            </button>
+            <button onClick={() => setShowNewFolderDialog(true)} className="p-1 hover:bg-muted rounded" title="New Folder">
+              <FolderPlus className="w-4 h-4" />
+            </button>
           </div>
-
-          {/* New File Dialog */}
-          {showNewFileDialog && (
-            <div className="mb-2 p-2 bg-muted rounded">
-              <input
-                type="text"
-                value={newFileName}
-                onChange={(e) => setNewFileName(e.target.value)}
-                placeholder="filename.ext"
-                className="w-full px-2 py-1 text-sm border rounded mb-2 bg-background"
-                onKeyDown={(e) => e.key === 'Enter' && addNewFile()}
-                autoFocus
-              />
-              <div className="flex gap-1">
-                <Button size="sm" onClick={addNewFile}>Add</Button>
-                <Button size="sm" variant="ghost" onClick={() => {
-                  setShowNewFileDialog(false)
-                  setNewFileName("")
-                }}>Cancel</Button>
-              </div>
-            </div>
-          )}
-
-          {/* New Folder Dialog */}
-          {showNewFolderDialog && (
-            <div className="mb-2 p-2 bg-muted rounded">
-              <input
-                type="text"
-                value={newFolderName}
-                onChange={(e) => setNewFolderName(e.target.value)}
-                placeholder="folder-name"
-                className="w-full px-2 py-1 text-sm border rounded mb-2 bg-background"
-                onKeyDown={(e) => e.key === 'Enter' && addNewFolder()}
-                autoFocus
-              />
-              <div className="flex gap-1">
-                <Button size="sm" onClick={addNewFolder}>Add</Button>
-                <Button size="sm" variant="ghost" onClick={() => {
-                  setShowNewFolderDialog(false)
-                  setNewFolderName("")
-                }}>Cancel</Button>
-              </div>
-            </div>
-          )}
-
-          <div className="flex-1 overflow-y-auto py-2">{renderFileTree(fileStructure)}</div>
         </div>
 
-        {/* Code Editor - Main panel */}
-        <div className="flex-1 flex flex-col h-full border border-border rounded-md overflow-hidden bg-card">
-          {/* Header with file name and action buttons */}
-          <div className="flex items-center justify-between gap-2 p-3 border-b border-border bg-muted/30">
-            <div className="flex-1 text-sm font-medium text-foreground">{selectedFile || "No file selected"}</div>
-            <div className="flex items-center gap-2">
-              {isEditing ? (
-                <>
-                  <Button variant="ghost" size="sm" onClick={handleSave} title="Save changes">
-                    <Save className="w-4 h-4 mr-1" />
-                    Save
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setIsEditing(false)} title="Cancel">
-                    Cancel
-                  </Button>
-                </>
-              ) : (
-                <Button variant="ghost" size="sm" onClick={handleEdit} title="Edit file">
-                  <Edit className="w-4 h-4 mr-1" />
-                  Edit
-                </Button>
-              )}
-              <Button variant="ghost" size="sm" onClick={copyCode} title="Copy code">
-                <Copy className="w-4 h-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={downloadAsZip}
-                disabled={isDownloading}
-                title="Download entire project"
-              >
-                <Download className="w-4 h-4" />
-              </Button>
+        {showNewFileDialog && (
+          <div className="mb-2 p-2 rounded bg-muted">
+            <input
+              className="w-full border rounded px-2 py-1 text-sm bg-background"
+              value={newFileName}
+              placeholder="filename.php"
+              onChange={(event) => setNewFileName(event.target.value)}
+              onKeyDown={(event) => event.key === "Enter" && addNewFile()}
+            />
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={addNewFile}>Add</Button>
+              <Button size="sm" variant="ghost" onClick={() => setShowNewFileDialog(false)}>Cancel</Button>
             </div>
           </div>
+        )}
 
-          {/* Code display/editor */}
-          {selectedFile ? (
-            <div className="flex-1 min-h-0 overflow-auto">
-              {isEditing ? (
-                <textarea
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  className="w-full h-full p-4 font-mono text-sm bg-[#282c34] text-white resize-none focus:outline-none"
-                  spellCheck={false}
-                  style={{
-                    fontFamily: 'Consolas, Monaco, "Courier New", monospace',
-                    tabSize: 2,
-                  }}
-                />
-              ) : (
-                <SyntaxHighlighter
-                  language={getLang(selectedFile)}
-                  style={okaidia}
-                  showLineNumbers
-                  wrapLines
-                  customStyle={{
-                    margin: 0,
-                    padding: "16px",
-                    fontFamily: "monospace",
-                    fontSize: "0.875rem",
-                    lineHeight: "1.5",
-                    backgroundColor: "#282c34",
-                    whiteSpace: "pre-wrap",
-                    wordWrap: "break-word",
-                  }}
-                >
-                  {fileContents[selectedFile] || "// Empty file"}
-                </SyntaxHighlighter>
-              )}
+        {showNewFolderDialog && (
+          <div className="mb-2 p-2 rounded bg-muted">
+            <input
+              className="w-full border rounded px-2 py-1 text-sm bg-background"
+              value={newFolderName}
+              placeholder="folder-name"
+              onChange={(event) => setNewFolderName(event.target.value)}
+              onKeyDown={(event) => event.key === "Enter" && addNewFolder()}
+            />
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={addNewFolder}>Add</Button>
+              <Button size="sm" variant="ghost" onClick={() => setShowNewFolderDialog(false)}>Cancel</Button>
             </div>
+          </div>
+        )}
+
+        <div className="overflow-auto flex-1">{renderTree(fileStructure)}</div>
+      </div>
+
+      <div className="flex-1 border border-border rounded-md overflow-hidden flex flex-col">
+        <div className="px-3 py-2 border-b border-border bg-muted/30 flex items-center justify-between gap-2">
+          <span className="text-sm font-medium truncate">{selectedFile}</span>
+          <div className="flex items-center gap-1">
+            {isEditing ? (
+              <>
+                <Button size="sm" variant="ghost" onClick={handleSave}><Save className="w-4 h-4 mr-1" />Save</Button>
+                <Button size="sm" variant="ghost" onClick={() => setIsEditing(false)}>Cancel</Button>
+              </>
+            ) : (
+              <Button size="sm" variant="ghost" onClick={() => { setIsEditing(true); setEditContent(fileContents[selectedFile] || "") }}>
+                <Edit className="w-4 h-4 mr-1" />Edit
+              </Button>
+            )}
+            <Button size="sm" variant="ghost" onClick={copyCode}><Copy className="w-4 h-4" /></Button>
+            <Button size="sm" variant="ghost" onClick={downloadProject}><Download className="w-4 h-4" /></Button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto">
+          {isEditing ? (
+            <textarea
+              className="w-full h-full p-4 bg-[#282c34] text-white font-mono text-sm resize-none outline-none"
+              value={editContent}
+              onChange={(event) => setEditContent(event.target.value)}
+              spellCheck={false}
+            />
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              Select a file to view code
-            </div>
+            <SyntaxHighlighter
+              language={getLanguage(selectedFile)}
+              style={okaidia}
+              showLineNumbers
+              customStyle={{ margin: 0, minHeight: "100%", backgroundColor: "#282c34" }}
+            >
+              {fileContents[selectedFile] || "// Empty file"}
+            </SyntaxHighlighter>
           )}
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Convert the code-editor view from an HTML-first, read-only snapshot into a fully functional PHP-oriented code workspace that mirrors the drag-and-drop design panel. 
- Ensure generated project output includes organized PHP views, assets, and a database schema so the visual design can be exported as a runnable PHP project. 
- Provide a VS Code-like file explorer with create/open/edit/delete and project export to let users manage generated files and folders. 

### Description
- Replaced the old HTML-first editor with a PHP project generator inside `src/components/CodeViewEditor.tsx` that produces a structured tree (folders: `public`, `app/views`, `public/assets`, `config`, `database`) and a set of auto-generated files protected from accidental deletion. 
- Added design-to-code generation functions that render canvas components into PHP view markup (`renderComponentToPHP` / `generateComponentPHP`), CSS (`generateCSS`), JS (`generateJS`), and a dynamic SQL schema for form components (`generateSchemaSQL`), and a PDO template for `config/database.php`. 
- Implemented a file-tree builder (`buildTreeFromPaths`), VS Code-like explorer and CRUD UX (create file/folder, open/edit/save, recursive delete with protection for auto-generated files, and full-project download/export) with syntax highlighting for `php`, `css`, `js`, `sql`, and `md`. 
- Outputs now include `public/index.php`, `app/views/layout.php`, `app/views/generated-components.php`, `public/assets/css/styles.css`, `public/assets/js/app.js`, `config/database.php`, `database/schema.sql`, and `README.md` synchronized from the design panel. 

### Testing
- Ran `npm run build` and the Vite production build completed successfully (warnings about unrelated duplicate switch cases remained but did not block the build). 
- Started the dev server with `npm run dev` and it launched successfully and accepted requests. 
- Captured a UI verification via an automated browser script (Playwright) which produced a screenshot of the updated PHP explorer view (artifact saved during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c031676883339e57d7733ce13582)